### PR TITLE
CI update for new pinto release

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -9,7 +9,6 @@ on:
 jobs:
   ci-tests:
     # set up Pinto container permissions
-    if: github.repository_owner == 'ML4GW'
     runs-on: ubuntu-latest
     permissions:
       packages: read
@@ -62,7 +61,7 @@ jobs:
           test_dir: /github/workspace/libs/architectures
         run: |
           pinto build $test_dir -E wrapper
-          pinto run $test_dir pytest $test_dir/tests
+          pinto -p $test_dir run pytest $test_dir/tests
 
       # test injection library before the libraries that depend on it
       -
@@ -70,7 +69,7 @@ jobs:
         if: steps.filter.outputs.injection == 'true'
         env:
           test_dir: /github/workspace/libs/injection
-        run: pinto run $test_dir pytest -x $test_dir/tests
+        run: pinto -p $test_dir run pytest -x $test_dir/tests
        
       # run dataloader tests if dataloader library code changed
       # _or_ if injection code (on which it depends) changed
@@ -84,7 +83,7 @@ jobs:
           || (steps.filter.outputs.data == 'true')
         env:
           test_dir: /github/workspace/libs/data
-        run: pinto run $test_dir pytest $test_dir/tests -m "not gpu"
+        run: pinto -p $test_dir run pytest $test_dir/tests -m "not gpu"
 
       # run trainer tests if architecture library has changed
       # or if data library has changed
@@ -96,7 +95,7 @@ jobs:
           || (steps.filter.outputs.architectures == 'true')     
         env:
             test_dir: /github/workspace/libs/trainer
-        run: pinto run $test_dir pytest $test_dir/tests 
+        run: pinto -p $test_dir run pytest $test_dir/tests 
       
       # test projects, and filter by both changes to
       # project code and their dependent libraries
@@ -107,7 +106,7 @@ jobs:
           && (steps.filter.outputs.generate_waveforms == 'true')
         env:
           test_dir: /github/workspace/projects/sandbox/generate_waveforms
-        run: pinto run $test_dir pytest $test_dir/tests
+        run: pinto -p $test_dir run pytest $test_dir/tests
         
       - 
         name: run glitch generation tests
@@ -115,4 +114,4 @@ jobs:
           (steps.filter.outputs.generate_glitches == 'true')
         env:
           test_dir: /github/workspace/projects/sandbox/generate_glitches
-        run: pinto run $test_dir pytest -x $test_dir/tests
+        run: pinto -p $test_dir run pytest -x $test_dir/tests

--- a/libs/injection/bbhnet/injection/injection.py
+++ b/libs/injection/bbhnet/injection/injection.py
@@ -1,8 +1,6 @@
-#!/usr/bin/env python
-# coding: utf-8
 import logging
-import os
 from collections.abc import Iterable
+from pathlib import Path
 
 import bilby
 import h5py
@@ -303,9 +301,9 @@ def inject_signals(
     )
     snr_list = [snr * new_snr / old_snr for snr in snr_list]
 
-    frame_out_paths = [
-        os.path.join(outdir, os.path.basename(frame)) for frame in frame_files
-    ]
+    outdir = Path(outdir)
+    frame_out_paths = [outdir / f.name for f in map(Path, frame_files)]
+
     for strain, signals, frame_path in zip(
         strains, signals_list, frame_out_paths
     ):
@@ -319,9 +317,7 @@ def inject_signals(
         strain.write(frame_path)
 
     # Write params and similar to output file
-    param_file = os.path.join(
-        outdir, f"param_file_{frame_start}-{frame_stop}.h5"
-    )
+    param_file = outdir / f"param_file_{frame_start}-{frame_stop}.h5"
     with h5py.File(param_file, "w") as f:
         # write signals attributes, snr, and signal parameters
         params_gr = f.create_group("signal_params")


### PR DESCRIPTION
An update of to `pinto` changed the way project paths get handled. This PR updates the CI workflow to use the new syntax, and introduces some small path-manipulation changes in the `injection` library so that the workflow actually gets run, since so many libraries and projects depend on it.