### PR TITLE
fixing export tests and injection library bug with py3.8

### DIFF
--- a/libs/injection/bbhnet/injection/injection.py
+++ b/libs/injection/bbhnet/injection/injection.py
@@ -1,6 +1,6 @@
 import logging
-from collections.abc import Iterable
 from pathlib import Path
+from typing import Iterable
 
 import bilby
 import h5py

--- a/projects/sandbox/export/tests/test_export.py
+++ b/projects/sandbox/export/tests/test_export.py
@@ -1,51 +1,54 @@
 import re
 import shutil
+from contextlib import nullcontext
+from pathlib import Path
 
 import pytest
 import torch
 from export import export
+from google.protobuf import text_format
+from tritonclient.grpc.model_config_pb2 import ModelConfig
 
 from bbhnet.architectures import ResNet
 from bbhnet.data.transforms import WhiteningTransform
 
 
-class AddOne(torch.nn.Module):
-    def __init__(self, num_ifos: int) -> None:
-        super().__init__()
-        self.num_ifos = num_ifos
-
-    def forward(self, x):
-        return x + 1
-
-
-@pytest.fixture(params=[128, 512])
-def sample_rate(request):
-    return request.param
+# set up a directory for the entirety of the session
+# which will store all the weight values of each
+# NN we need to create in response to a particular
+# num_ifos/sample_rate/kernel_length combination
+@pytest.fixture(scope="session")
+def weights_dir():
+    weights_dir = Path(__file__).resolve().parent / "weights"
+    weights_dir.mkdir(exist_ok=True)
+    yield weights_dir
+    shutil.rmtree(weights_dir)
 
 
-@pytest.fixture(params=[1, 4, 8])
-def inference_sampling_rate(request):
-    return request.param
+# only create a new neural network if the weights for
+# a network of this num_ifos/sample_rate/kernel_length
+# combination has not yet been created. Otherwise just
+# return the path to those weights as-is
+@pytest.fixture
+def architecture():
+    return lambda num_ifos: ResNet(num_ifos, [2, 2])
 
 
-@pytest.fixture(params=[0.5, 1, 2])
-def kernel_length(request):
-    return request.param
+@pytest.fixture
+def get_network_weights(weights_dir, architecture):
+    def fn(num_ifos, sample_rate, kernel_length, target):
+        weights = weights_dir / f"{num_ifos}-{sample_rate}-{kernel_length}.pt"
+        if not weights.exists():
+            preprocessor = WhiteningTransform(
+                num_ifos, sample_rate, kernel_length
+            )
+            bbhnet = architecture(num_ifos)
+            model = torch.nn.Sequential(preprocessor, bbhnet)
+            torch.save(model.state_dict(prefix=""), weights)
 
+        shutil.copy(weights, target)
 
-@pytest.fixture(params=[None, 1, 2])
-def instances(request):
-    return request.param
-
-
-@pytest.fixture(params=[1, 4])
-def streams_per_gpu(request):
-    return request.param
-
-
-@pytest.fixture(params=[1, 2, 4])
-def num_ifos(request):
-    return request.param
+    return fn
 
 
 @pytest.fixture
@@ -55,80 +58,253 @@ def repo_dir(tmp_path):
     return repo
 
 
-@pytest.fixture(params=[None, "", "weights.pt", "other.pdf"])
-def weights(request):
+@pytest.fixture
+def output_dir(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    return output_dir
+
+
+def load_config(config_path: Path):
+    config = ModelConfig()
+    text_format.Merge(config_path.read_text(), config)
+    return config
+
+
+@pytest.fixture
+def validate_repo(repo_dir):
+    def fn(
+        expected_instances,
+        expected_snapshots,
+        expected_versions,
+        expected_num_ifos,
+        expected_stream_size,
+        expected_kernel_size,
+    ):
+        for i, model in enumerate(repo_dir.iterdir()):
+            config = load_config(model / "config.pbtxt")
+            if model.name == "snapshotter":
+                try:
+                    instance_group = config.instance_group[0]
+                except IndexError:
+                    if expected_snapshots is not None:
+                        raise ValueError(
+                            "No instance group but expected snapshots "
+                            f"is {expected_snapshots}"
+                        )
+                else:
+                    if expected_snapshots is None:
+                        raise ValueError(
+                            "Didn't expect snapshots but found "
+                            f"instance group {instance_group}"
+                        )
+                    assert instance_group.count == expected_snapshots
+
+                assert config.input[0].dims[1] == expected_num_ifos
+                assert config.input[0].dims[2] == expected_stream_size
+
+                assert config.output[0].dims[1] == expected_num_ifos
+                assert config.output[0].dims[2] == expected_kernel_size
+
+                assert (model / "1" / "model.savedmodel").is_dir()
+                assert not (model / "2").is_dir()
+            elif model.name == "bbhnet":
+                try:
+                    instance_group = config.instance_group[0]
+                except IndexError:
+                    if expected_instances is not None:
+                        raise ValueError(
+                            "No instance group but expected instances "
+                            f"is {expected_instances}"
+                        )
+                else:
+                    if expected_instances is None:
+                        raise ValueError(
+                            "Didn't expect bbhnet instances but found "
+                            f"instance group {instance_group}"
+                        )
+                    assert instance_group.count == expected_instances
+
+                assert config.input[0].dims[1] == expected_num_ifos
+                assert config.input[0].dims[2] == expected_kernel_size
+                assert [j == 1 for j in config.output[0].dims]
+
+                for j in range(expected_versions):
+                    assert (model / str(j + 1) / "model.onnx").is_file()
+                assert not (model / str(j + 2)).is_dir()
+            elif model.name == "bbhnet-stream":
+                assert (model / "1").is_dir()
+                assert not (model / "2").is_dir()
+            else:
+                raise ValueError(f"Unexpected model {model.name} in repo")
+
+        assert i == 2, f"Wrong number of models {i + 1}"
+
+    return fn
+
+
+# first set of tests will check that all the properties
+# of the inputs to the neural network get set up properly
+@pytest.fixture
+def num_ifos():
+    return 2
+
+
+@pytest.fixture
+def sample_rate():
+    return 128
+
+
+@pytest.fixture(params=[1, 4, 8])
+def inference_sampling_rate(request):
     return request.param
 
 
+@pytest.fixture(params=[1, 2])
+def kernel_length(request):
+    return request.param
+
+
+def test_export_for_shapes(
+    repo_dir,
+    output_dir,
+    num_ifos,
+    sample_rate,
+    kernel_length,
+    inference_sampling_rate,
+    architecture,
+    get_network_weights,
+    validate_repo,
+):
+    weights = output_dir / "weights.pt"
+    get_network_weights(num_ifos, sample_rate, kernel_length, weights)
+
+    # test fully from scratch behavior
+    if kernel_length < (1 / inference_sampling_rate):
+        context = pytest.raises(ValueError)
+    else:
+        context = nullcontext()
+
+    with context:
+        export(
+            architecture,
+            str(repo_dir),
+            output_dir,
+            num_ifos=num_ifos,
+            kernel_length=kernel_length,
+            inference_sampling_rate=inference_sampling_rate,
+            sample_rate=sample_rate,
+            weights=weights,
+            streams_per_gpu=1,
+            instances=1,
+        )
+        validate_repo(
+            expected_instances=1,
+            expected_snapshots=1,
+            expected_versions=1,
+            expected_num_ifos=num_ifos,
+            expected_stream_size=int(sample_rate / inference_sampling_rate),
+            expected_kernel_size=int(sample_rate * kernel_length),
+        )
+
+
+# next test how passing different values of the
+# `weights` parameter causes different behavior.
+# - `None` will indicate to not pass anything to the function,
+#       which it will use to infer that it should look for
+#       a `weights.pt` file in the `output_dir`
+# - `None` will indicate to pass output_dir to `weights, which
+#       will indicate that this is a directory that it ought
+#       to check for a `weights.pt`
+# - `weights.pt` indicates a full, sensible path to a weights file
+# - `other.pdf` just tests that even with a weird name, the
+#       path is still resolved appropriately
+@pytest.mark.parametrize("weights", [None, "", "weights.pt", "other.pdf"])
+def test_export_for_weights(
+    repo_dir,
+    output_dir,
+    weights,
+    architecture,
+    get_network_weights,
+    validate_repo,
+):
+    num_ifos = 2
+    kernel_length = 1
+    sample_rate = 128
+    inference_sampling_rate = 4
+
+    if not weights:
+        target = output_dir / "weights.pt"
+        if weights is None:
+            weights = output_dir
+        else:
+            weights = output_dir / "weights.pt"
+    else:
+        weights = target = output_dir / weights
+    get_network_weights(num_ifos, sample_rate, kernel_length, target)
+
+    export(
+        architecture,
+        str(repo_dir),
+        output_dir,
+        num_ifos=num_ifos,
+        kernel_length=kernel_length,
+        inference_sampling_rate=inference_sampling_rate,
+        sample_rate=sample_rate,
+        weights=weights,
+        streams_per_gpu=1,
+        instances=1,
+    )
+    validate_repo(
+        expected_instances=1,
+        expected_snapshots=1,
+        expected_versions=1,
+        expected_num_ifos=num_ifos,
+        expected_stream_size=int(sample_rate / inference_sampling_rate),
+        expected_kernel_size=int(sample_rate * kernel_length),
+    )
+
+
+# now test how different values of scaling parameters
+# lead to different configs
+@pytest.fixture(params=[None, 1])
+def instances(request):
+    return request.param
+
+
+@pytest.fixture(params=[1, 4])
+def streams_per_gpu(request):
+    return request.param
+
+
+# indicates whether we ought to delete the contents
+# of the model repository before doing export
 @pytest.fixture(params=[True, False])
 def clean(request):
     return request.param
 
 
-@pytest.fixture
-def output_dir(tmp_path, num_ifos, sample_rate, kernel_length, weights):
-    output_dir = tmp_path / "output"
-    output_dir.mkdir()
-
-    weights = weights or "weights.pt"
-    preprocessor = WhiteningTransform(num_ifos, sample_rate, kernel_length)
-    bbhnet = ResNet(num_ifos, [2, 2])
-    model = torch.nn.Sequential(preprocessor, bbhnet)
-    torch.save(model.state_dict(prefix=""), output_dir / weights)
-    return output_dir
-
-
-def test_export(
+def test_export_for_scaling(
     repo_dir,
     output_dir,
-    num_ifos,
-    kernel_length,
-    inference_sampling_rate,
-    sample_rate,
     streams_per_gpu,
     instances,
-    weights,
     clean,
+    architecture,
+    validate_repo,
+    get_network_weights,
 ):
-    if weights == "":
-        weights = output_dir
-    elif weights is not None:
-        weights = output_dir / weights
+    num_ifos = 2
+    kernel_length = 1
+    sample_rate = 128
+    inference_sampling_rate = 4
 
-    def validate_repo(instances, versions):
-        models = [i.name for i in repo_dir.iterdir()]
-        assert len(models) == 3
-        assert set(models) == set(["bbhnet", "snapshotter", "bbhnet-stream"])
-
-        # verify that the instance group scale is correct
-        bbhnet_config = repo_dir / "bbhnet" / "config.pbtxt"
-        assert bbhnet_config.exists()
-        config = bbhnet_config.read_text()
-        has_scale = f"count: {instances}" in config
-        assert has_scale ^ (instances is None)
-
-        # TODO: check shapes in config
-        # is this our business or do we trust quiver to test
-        # for this correctly? I guess it's more of a test as
-        # to whether we fed the arguments to quiver correctly
-
-        # verify that we have all the versions we expect of bbhnet
-        bbhnet_versions = list((repo_dir / "bbhnet").iterdir())
-        bbhnet_versions = [i.name for i in bbhnet_versions]
-        for i in range(1, versions + 1):
-            assert str(i) in bbhnet_versions
-            assert (repo_dir / "bbhnet" / str(i) / "model.onnx").is_file()
-
-        # make sure we only ever have one snapshotter
-        # and ensemble model version
-        assert len(list((repo_dir / "snapshotter").iterdir())) == 2
-        assert len(list((repo_dir / "bbhnet-stream").iterdir())) == 2
-
-        # TODO: check shapes in configs
+    weights = output_dir / "weights.pt"
+    get_network_weights(num_ifos, sample_rate, kernel_length, weights)
 
     def run_export(instances=instances, clean=clean):
         export(
-            lambda num_ifos: ResNet(num_ifos, [2, 2]),
+            architecture,
             str(repo_dir),
             output_dir,
             num_ifos=num_ifos,
@@ -141,27 +317,41 @@ def test_export(
             clean=clean,
         )
 
-    # test fully from scratch behavior
-    if kernel_length < (1 / inference_sampling_rate):
-        with pytest.raises(ValueError):
-            run_export()
-        return
-
     run_export()
-    validate_repo(instances, 1)
+    validate_repo(
+        expected_instances=instances,
+        expected_snapshots=streams_per_gpu,
+        expected_versions=1,
+        expected_num_ifos=num_ifos,
+        expected_stream_size=int(sample_rate / inference_sampling_rate),
+        expected_kernel_size=int(sample_rate * kernel_length),
+    )
 
     # now check what happens if the repo already exists
     run_export()
-    validate_repo(instances, 1 if clean else 2)
+    validate_repo(
+        expected_instances=instances,
+        expected_snapshots=streams_per_gpu,
+        expected_versions=1 if clean else 2,
+        expected_num_ifos=num_ifos,
+        expected_stream_size=int(sample_rate / inference_sampling_rate),
+        expected_kernel_size=int(sample_rate * kernel_length),
+    )
 
     # now make sure if we change the scale
     # we get another version and the config changes
     run_export(instances=3, clean=False)
-    validate_repo(3, 2 if clean else 3)
+    validate_repo(
+        expected_instances=3,
+        expected_snapshots=streams_per_gpu,
+        expected_versions=2 if clean else 3,
+        expected_num_ifos=num_ifos,
+        expected_stream_size=int(sample_rate / inference_sampling_rate),
+        expected_kernel_size=int(sample_rate * kernel_length),
+    )
 
-    # now test to make sure an error gets raised if
-    # the ensemble already exists but bbhnet is not
-    # part of it
+    # now test to make sure an error gets raised if the
+    # ensemble already exists but bbhnet is not part of it
     shutil.move(repo_dir / "bbhnet", repo_dir / "bbbhnet")
     bbhnet_config = repo_dir / "bbbhnet" / "config.pbtxt"
     config = bbhnet_config.read_text()
@@ -185,4 +375,11 @@ def test_export(
     # ensemble section that deletes the most recent
     # bbhnet version if things go wrong?
     shutil.rmtree(repo_dir / "bbbhnet")
-    validate_repo(None, 1)
+    validate_repo(
+        expected_instances=instances,
+        expected_snapshots=streams_per_gpu,
+        expected_versions=1,
+        expected_num_ifos=num_ifos,
+        expected_stream_size=int(sample_rate / inference_sampling_rate),
+        expected_kernel_size=int(sample_rate * kernel_length),
+    )


### PR DESCRIPTION
Vastly reducing the time required to run the tests for the export project by reducing the scope of individual tests, removing permutations that don't add insight, and caching model weights when possible. Closes #85 