### PR TITLE
add power law distribution

### DIFF
--- a/libs/data/bbhnet/data/distributions.py
+++ b/libs/data/bbhnet/data/distributions.py
@@ -71,3 +71,40 @@ class LogNormal:
         if self.low is not None:
             x = torch.clip(x, self.low)
         return x
+
+
+class PowerLaw:
+    """
+    Sample from a power law distribution,
+    .. math::
+        p(x) \approx x^{-\alpha}.
+
+    Index alpha must be greater than 1.
+    This could be used, for example, as a universal distribution of
+    signal-to-noise ratios (SNRs) from uniformly volume distributed
+    sources
+    .. math::
+
+       p(\rho) = 3*\rho_0^3 / \rho^4
+
+    where :math:`\rho_0` is a representative minimum SNR
+    considered for detection. See, for example,
+    `Schutz (2011) <https://arxiv.org/abs/1102.5421>`_.
+    """
+
+    def __init__(
+        self, x_min: float, x_max: float = float("inf"), alpha: float = 2
+    ) -> None:
+        self.x_min = x_min
+        self.x_max = x_max
+        self.alpha = alpha
+
+        self.normalization = x_min ** (-self.alpha + 1)
+        self.normalization -= x_max ** (-self.alpha + 1)
+
+    def __call__(self, N: int) -> torch.Tensor:
+        u = torch.rand(N)
+        u *= self.normalization
+        samples = self.x_min ** (-self.alpha + 1) - u
+        samples = torch.pow(samples, -1.0 / (self.alpha - 1))
+        return samples

--- a/libs/data/tests/test_distributions.py
+++ b/libs/data/tests/test_distributions.py
@@ -1,5 +1,9 @@
 from math import pi
 
+import numpy as np
+import pytest
+from scipy import optimize
+
 from bbhnet.data import distributions
 
 # TODO: for all tests, how to validate that
@@ -57,3 +61,23 @@ def test_log_normal():
     samples = sampler(10000)
     mean = samples.mean().item()
     assert (abs(mean - 10) / 10) < (2 * 2 / 10000**0.5)
+
+
+def test_volume_distributed_snr():
+    """Test PowerLaw distribution against expected distribution of SNRs"""
+    ref_snr = 8
+    sampler = distributions.PowerLaw(
+        x_min=ref_snr, x_max=float("inf"), alpha=4
+    )
+    samples = sampler(10000).numpy()
+    # check 1/rho^4 behavior
+    counts, ebins = np.histogram(samples, bins=100)
+    bins = ebins[1:] + ebins[:-1]
+    bins *= 0.5
+
+    def foo(x, a, b):
+        return a * x ** (-b)
+
+    popt, pcov = optimize.curve_fit(foo, bins, counts, (20, 3))
+    # popt[1] is the index
+    assert popt[1] == pytest.approx(4, rel=1e-1)


### PR DESCRIPTION
Add amplitude distribution based on a volume distributed sources. This follows a power law with index -4. E.g.
![image](https://user-images.githubusercontent.com/23223278/200196899-26442a93-22f8-45d1-81b0-af268da032ac.png)
