### PR TITLE
Validation fixes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -100,3 +100,4 @@ projects/sandbox/train/:
   - 'libs/trainer/**'
   - 'libs/logging/**'
   - 'libs/data/**'
+  - 'ml4gw/**'

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -84,6 +84,7 @@ projects/sandbox/infer/:
   - 'projects/sandbox/infer/**'
   - 'hermes/hermes/hermes.stillwater/**'
   - 'hermes/hermes/hermes.aerial/**'
+
 projects/sandbox/timeslide_injections/:
   - *workflow
   - 'projects/sandbox/timeslide_injections/**'
@@ -92,3 +93,10 @@ projects/sandbox/timeslide_injections/:
   - 'libs/logging/**' 
   - 'libs/parallelize/**'
   - 'ml4gw/**'
+
+projects/sandbox/train/:
+  - *workflow
+  - 'projects/sandbox/train/**'
+  - 'libs/trainer/**'
+  - 'libs/logging/**'
+  - 'libs/data/**'

--- a/libs/trainer/bbhnet/trainer/trainer.py
+++ b/libs/trainer/bbhnet/trainer/trainer.py
@@ -222,6 +222,3 @@ def train(
         )
         if stop:
             break
-
-    if validator is not None:
-        validator.save()

--- a/libs/trainer/bbhnet/trainer/trainer.py
+++ b/libs/trainer/bbhnet/trainer/trainer.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pickle
 import time
 from typing import Callable, Iterable, Optional, Tuple
 
@@ -14,7 +13,7 @@ def train_for_one_epoch(
     optimizer: torch.optim.Optimizer,
     criterion: torch.nn.Module,
     train_dataset: Iterable[Tuple[np.ndarray, np.ndarray]],
-    valid_dataset: Iterable[Tuple[np.ndarray, np.ndarray]] = None,
+    validator: Optional[Callable] = None,
     profiler: Optional[torch.profiler.profile] = None,
     scaler: Optional[torch.cuda.amp.GradScaler] = None,
     scheduler: Optional[Callable] = None,
@@ -25,7 +24,6 @@ def train_for_one_epoch(
     samples_seen = 0
     start_time = time.time()
     model.train()
-    device = next(model.parameters()).device
 
     for samples, targets in train_dataset:
         optimizer.zero_grad(set_to_none=True)  # reset gradient
@@ -64,34 +62,11 @@ def train_for_one_epoch(
             duration, throughput
         )
     )
-    msg = f"Train Loss: {train_loss:.4e}"
-
     # Evaluate performance on validation set if given
-    if valid_dataset is not None:
-        valid_loss = 0
-        samples_seen = 0
-
+    if validator is not None:
         model.eval()
-
-        # reason mixed precision is not used here?
-        # since no gradient calculation that requires
-        # higher precision?
-        with torch.no_grad():
-            for samples, targets in valid_dataset:
-                samples, targets = samples.to(device), targets.to(device)
-                predictions = model(samples)
-                loss = criterion(predictions, targets)
-
-                valid_loss += loss.item()
-                samples_seen += len(samples)
-
-        valid_loss /= samples_seen
-        msg += f", Valid Loss: {valid_loss:.4e}"
-    else:
-        valid_loss = None
-
-    logging.info(msg)
-    return train_loss, valid_loss, duration, throughput
+        return validator(model, train_loss)
+    return False
 
 
 def train(
@@ -99,7 +74,7 @@ def train(
     outdir: str,
     # data params
     train_dataset: Iterable[Tuple[np.ndarray, np.ndarray]],
-    valid_dataset: Iterable[Tuple[np.ndarray, np.ndarray]] = None,
+    validator: Optional[Callable] = None,
     preprocessor: Optional[torch.nn.Module] = None,
     # optimization params
     max_epochs: int = 40,
@@ -108,12 +83,11 @@ def train(
     min_lr: float = 1e-5,
     decay_steps: int = 10000,
     weight_decay: float = 0.0,
-    early_stop: int = 20,
     # misc params
     device: Optional[str] = None,
     use_amp: bool = False,
     profile: bool = False,
-) -> float:
+) -> None:
     """Train BBHnet model on in-memory data
     Args:
         architecture:
@@ -222,10 +196,6 @@ def train(
     elif use_amp:
         logging.warning("'use_amp' flag set but no cuda device, ignoring")
 
-    best_valid_loss = np.inf
-    since_last_improvement = 0
-    history = {"train_loss": [], "valid_loss": []}
-
     logging.info("Beginning training loop")
     for epoch in range(max_epochs):
         if epoch == 0 and profile:
@@ -240,55 +210,18 @@ def train(
             profiler = None
 
         logging.info(f"=== Epoch {epoch + 1}/{max_epochs} ===")
-        train_loss, valid_loss, duration, throughput = train_for_one_epoch(
+        stop = train_for_one_epoch(
             model,
             optimizer,
             criterion,
             train_dataset,
-            valid_dataset,
+            validator,
             profiler,
             scaler,
             lr_scheduler,
         )
+        if stop:
+            break
 
-        history["train_loss"].append(train_loss)
-
-        # do some house cleaning with our
-        # validation loss if we have one
-        if valid_loss is not None:
-            history["valid_loss"].append(valid_loss)
-
-            # update our learning rate scheduler if we
-            # indicated a schedule with `patience`
-            # if patience is not None:
-            #     lr_scheduler.step(valid_loss)
-
-            # save this version of the model weights if
-            # we achieved a new best loss, otherwise check
-            # to see if we need to early stop based on
-            # plateauing validation loss
-            if valid_loss < best_valid_loss:
-                logging.debug(
-                    "Achieved new lowest validation loss, "
-                    "saving model weights"
-                )
-                best_valid_loss = valid_loss
-
-                weights_path = os.path.join(outdir, "weights.pt")
-                torch.save(model.state_dict(), weights_path)
-                since_last_improvement = 0
-            else:
-                since_last_improvement += 1
-                if since_last_improvement >= early_stop:
-                    logging.info(
-                        "No improvement in validation loss in {} "
-                        "epochs, halting training early".format(early_stop)
-                    )
-                    break
-
-    with open(os.path.join(outdir, "history.pkl"), "wb") as f:
-        pickle.dump(history, f)
-
-    # TODO: Make it so that return statements don't break things
-    # return the training results
-    # return history
+    if validator is not None:
+        validator.save()

--- a/libs/trainer/bbhnet/trainer/wrapper.py
+++ b/libs/trainer/bbhnet/trainer/wrapper.py
@@ -72,7 +72,7 @@ def trainify(f):
         # use the passed function `f` to return data files
         # f returns training and validation
         # glitch, signal and background dataset files
-        train_dataset, valid_dataset, preprocessor = f(*args, **kwargs)
+        train_dataset, validator, preprocessor = f(*args, **kwargs)
 
         # pass any args passed to this wrapper that
         # `train` needs into the `train_kwargs` dictionary
@@ -87,7 +87,7 @@ def trainify(f):
 
         # add in the parsed data to our training kwargs
         train_kwargs["train_dataset"] = train_dataset
-        train_kwargs["valid_dataset"] = valid_dataset
+        train_kwargs["validator"] = validator
         train_kwargs["preprocessor"] = preprocessor
 
         # allow wrapper functionality to be utilized if
@@ -113,13 +113,12 @@ def trainify(f):
             # hood with the arguments we populated into
             # `train_kwargs`
 
-            result = arch_fn(**arch_kwargs)
+            arch_fn(**arch_kwargs)
+            return None
         else:
             # otherwise just return the train and valid datasets, equivalent
             # to running `f` without any wrapper functionality
-            result = train_dataset, valid_dataset, preprocessor
-
-        return result
+            return train_dataset, validator, preprocessor
 
     # create the appropriate signature, name, and documentation
     # for the wrapper function we just created

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -113,9 +113,14 @@ lr = 4e-3
 min_lr = 1e-5
 decay_steps = 10000
 weight_decay = 1e-5
-early_stop = 20
+
+# validation parameters
 valid_frac = "${base.valid_frac}"
 valid_stride = 0.0625
+early_stop = 20
+monitor_metric = "glitch"
+threshold = 1.0
+checkpoint_every = 5
 
 # misc params
 device = "cuda"

--- a/projects/sandbox/train/poetry.lock
+++ b/projects/sandbox/train/poetry.lock
@@ -11,9 +11,17 @@ numpy = ">=1.17"
 pyerfa = ">=1.7.3"
 
 [package.extras]
-all = ["PyYAML (>=3.13)", "asdf (>=2.6)", "beautifulsoup4", "bleach", "bottleneck", "certifi", "dask[array]", "h5py", "html5lib", "ipython (>=4.2)", "jplephem", "matplotlib (>=3.0,!=3.4.0)", "mpmath", "pandas", "pytest", "pytz", "scipy (>=1.1)", "sortedcontainers"]
-docs = ["PyYAML (>=3.13)", "matplotlib (>=3.1,!=3.4.0)", "packaging", "pytest", "scipy (>=1.1)", "sphinx (<4)", "sphinx-astropy (>=1.3)", "sphinx-changelog (>=1.1.0)"]
-test = ["coverage", "ipython (>=4.2)", "objgraph", "packaging", "pytest-astropy (>=0.8)", "pytest-xdist", "sgp4 (>=2.3)", "skyfield (>=1.20)"]
+all = ["scipy (>=1.1)", "certifi", "dask", "h5py", "beautifulsoup4", "html5lib", "bleach", "PyYAML (>=3.13)", "pandas", "sortedcontainers", "pytz", "jplephem", "matplotlib (>=3.0,!=3.4.0)", "mpmath", "asdf (>=2.6)", "bottleneck", "ipython (>=4.2)", "pytest"]
+docs = ["sphinx (<4)", "sphinx-astropy (>=1.3)", "pytest", "PyYAML (>=3.13)", "scipy (>=1.1)", "matplotlib (>=3.1,!=3.4.0)", "sphinx-changelog (>=1.1.0)", "packaging"]
+test = ["pytest-astropy (>=0.8)", "pytest-xdist", "objgraph", "ipython (>=4.2)", "coverage", "skyfield (>=1.20)", "sgp4 (>=2.3)", "packaging"]
+
+[[package]]
+name = "atomicwrites"
+version = "1.4.1"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
@@ -24,10 +32,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
-docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
-tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bbhnet-architectures"
@@ -196,7 +204,7 @@ optional = false
 python-versions = ">=3.6.0"
 
 [package.extras]
-unicode-backport = ["unicodedata2"]
+unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -218,11 +226,11 @@ python-versions = ">=3.7"
 numpy = ">=1.16"
 
 [package.extras]
-bokeh = ["bokeh", "selenium"]
-docs = ["docutils (<0.18)", "sphinx", "sphinx-rtd-theme"]
-test = ["Pillow", "flake8", "isort", "matplotlib", "pytest"]
+test-no-codebase = ["pillow", "matplotlib", "pytest"]
 test-minimal = ["pytest"]
-test-no-codebase = ["Pillow", "matplotlib", "pytest"]
+test = ["isort", "flake8", "pillow", "matplotlib", "pytest"]
+docs = ["sphinx-rtd-theme", "sphinx", "docutils (<0.18)"]
+bokeh = ["selenium", "bokeh"]
 
 [[package]]
 name = "corner"
@@ -237,9 +245,9 @@ matplotlib = ">=2.1"
 
 [package.extras]
 arviz = ["arviz (>=0.9)"]
-dev = ["arviz (>=0.9)", "black", "flake8", "isort", "myst-nb", "pandoc", "pep517", "pre-commit", "pytest (>=3.6)", "pytest-cov (>=2.6.1)", "sphinx (>=1.7.5)", "sphinx-book-theme", "toml", "twine"]
-docs = ["arviz (>=0.9)", "myst-nb", "pandoc", "sphinx (>=1.7.5)", "sphinx-book-theme"]
-test = ["black", "isort", "pytest (>=3.6)", "pytest-cov (>=2.6.1)", "toml"]
+dev = ["pytest (>=3.6)", "pytest-cov (>=2.6.1)", "black", "isort", "toml", "arviz (>=0.9)", "sphinx (>=1.7.5)", "pandoc", "myst-nb", "sphinx-book-theme", "pre-commit", "flake8", "pep517", "twine"]
+docs = ["arviz (>=0.9)", "sphinx (>=1.7.5)", "pandoc", "myst-nb", "sphinx-book-theme"]
+test = ["pytest (>=3.6)", "pytest-cov (>=2.6.1)", "black", "isort", "toml"]
 
 [[package]]
 name = "cryptography"
@@ -254,11 +262,11 @@ cffi = ">=1.12"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "sphinxcontrib-spelling (>=4.0.1)", "twine (>=1.12.0)"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools-rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["hypothesis (>=1.11.4,!=3.79.2)", "iso8601", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pytz"]
+test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
 name = "cycler"
@@ -292,9 +300,9 @@ igwn-auth-utils = ">=0.3.1"
 ligo-segments = ">=1.0.0"
 
 [package.extras]
-docs = ["sphinx", "sphinx-automodapi", "sphinx-immaterial"]
-lint = ["flake8 (>=3.7.0)", "flake8-bandit"]
-test = ["pytest (>=2.9.2)", "pytest-cov (>=2.5.1)", "requests-mock (>=1.5.0)"]
+test = ["requests-mock (>=1.5.0)", "pytest-cov (>=2.5.1)", "pytest (>=2.9.2)"]
+lint = ["flake8-bandit", "flake8 (>=3.7.0)"]
+docs = ["sphinx-immaterial", "sphinx-automodapi", "sphinx"]
 
 [[package]]
 name = "dynesty"
@@ -323,7 +331,7 @@ numpy = "*"
 
 [package.extras]
 extras = ["h5py", "scipy"]
-tests = ["coverage[toml]", "pytest", "pytest-cov"]
+tests = ["pytest", "pytest-cov", "coverage"]
 
 [[package]]
 name = "fonttools"
@@ -334,9 +342,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=14.0.0)", "xattr", "zopfli (>=0.1.4)"]
+all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "skia-pathops (>=0.5.0)", "uharfbuzz (>=0.23.0)", "brotlicffi (>=0.8.0)", "scipy", "brotli (>=1.0.1)", "munkres", "unicodedata2 (>=14.0.0)", "xattr"]
 graphite = ["lz4 (>=1.7.4.2)"]
-interpolatable = ["munkres", "scipy"]
+interpolatable = ["scipy", "munkres"]
 lxml = ["lxml (>=4.0,<5)"]
 pathops = ["skia-pathops (>=0.5.0)"]
 plot = ["matplotlib"]
@@ -345,7 +353,7 @@ symfont = ["sympy"]
 type1 = ["xattr"]
 ufo = ["fs (>=2.2.0,<3)"]
 unicode = ["unicodedata2 (>=14.0.0)"]
-woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
+woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
 
 [[package]]
 name = "gwdatafind"
@@ -360,9 +368,9 @@ igwn-auth-utils = ">=0.3.1"
 ligo-segments = "*"
 
 [package.extras]
-docs = ["numpydoc", "sphinx (>=1.8.0)", "sphinx-automodapi", "sphinx-rtd-theme", "sphinx-tabs"]
-lint = ["flake8", "flake8-bandit", "flake8-docstrings", "radon"]
-test = ["pytest (>=2.8.0)", "pytest-cov", "requests-mock"]
+test = ["requests-mock", "pytest-cov", "pytest (>=2.8.0)"]
+lint = ["radon", "flake8-docstrings", "flake8-bandit", "flake8"]
+docs = ["sphinx-tabs", "sphinx-rtd-theme", "sphinx-automodapi", "sphinx (>=1.8.0)", "numpydoc"]
 
 [[package]]
 name = "gwosc"
@@ -376,8 +384,8 @@ python-versions = ">=3.5"
 requests = ">=1.0.0"
 
 [package.extras]
-docs = ["sphinx", "sphinx-automodapi", "sphinx-rtd-theme"]
-test = ["pytest (>=2.7.0)", "pytest-cov", "pytest-socket", "requests-mock (>=1.5.0)"]
+test = ["requests-mock (>=1.5.0)", "pytest-socket", "pytest-cov", "pytest (>=2.7.0)"]
+docs = ["sphinx-rtd-theme", "sphinx-automodapi", "sphinx"]
 
 [[package]]
 name = "gwpy"
@@ -402,8 +410,8 @@ scipy = ">=1.2.0"
 tqdm = ">=4.10.0"
 
 [package.extras]
-conda = ["python-framel (>=8.40.1)", "python-ldas-tools-framecpp", "python-nds2-client"]
-dev = ["astropy (<5.1a0)", "ciecplib", "lalsuite", "lscsoft-glue", "maya", "pandas", "psycopg2", "pyRXP", "pycbc (>=1.13.4)", "pymysql", "python-ligo-lw (>=1.7.0)", "sqlalchemy", "uproot (>=3.11)", "uproot3"]
+conda = ["python-framel (>=8.40.1)", "python-nds2-client", "python-ldas-tools-framecpp"]
+dev = ["ciecplib", "maya", "pandas", "psycopg2", "pymysql", "pyrxp", "sqlalchemy", "uproot (>=3.11)", "uproot3", "astropy (<5.1a0)", "lalsuite", "lscsoft-glue", "pycbc (>=1.13.4)", "python-ligo-lw (>=1.7.0)"]
 docs = ["numpydoc (>=0.8.0)", "requests", "sphinx (>=4.0.0)", "sphinx-automodapi", "sphinx-material (>=0.0.32)", "sphinx-panels (>=0.6.0)", "sphinxcontrib-programoutput"]
 test = ["coverage[toml] (>=5.0)", "freezegun (>=0.3.12)", "pytest (>=3.9.1)", "pytest-cov (>=2.4.0)", "pytest-socket", "pytest-xdist", "requests-mock"]
 
@@ -452,9 +460,17 @@ safe-netrc = ">=1.0.0"
 scitokens = ">=1.7.0"
 
 [package.extras]
-docs = ["sphinx (>=4.0.0)", "sphinx-immaterial-igwn"]
-lint = ["flake8 (>=3.7.0)", "flake8-bandit"]
-test = ["pytest (>=3.9.1)", "pytest-cov", "requests (>=2.14)", "requests-mock", "safe-netrc (>=1.0.0)"]
+test = ["safe-netrc (>=1.0.0)", "requests-mock", "requests (>=2.14)", "pytest-cov", "pytest (>=3.9.1)"]
+lint = ["flake8-bandit", "flake8 (>=3.7.0)"]
+docs = ["sphinx-immaterial-igwn", "sphinx (>=4.0.0)"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "kiwisolver"
@@ -567,7 +583,7 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-build = ["blurb", "twine", "wheel"]
+build = ["twine", "wheel", "blurb"]
 docs = ["sphinx"]
 test = ["pytest (<5.4)", "pytest-cov"]
 
@@ -618,7 +634,7 @@ python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
+test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
 
 [[package]]
 name = "pillow"
@@ -631,6 +647,26 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo", "olefile", "sphinx (>=2.4)", "sphinx-copybutton", "sphinx-issues (>=3.0.1)", "sphinx-removed-in", "sphinxext-opengraph"]
 tests = ["check-manifest", "coverage", "defusedxml", "markdown2", "olefile", "packaging", "pyroma", "pytest", "pytest-cov", "pytest-timeout"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+testing = ["pytest-benchmark", "pytest"]
+dev = ["tox", "pre-commit"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycparser"
@@ -665,9 +701,9 @@ python-versions = ">=3.7"
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+dev = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope-interface", "cryptography (>=3.4.0)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "pre-commit"]
+docs = ["sphinx (>=4.5.0,<5.0.0)", "sphinx-rtd-theme", "zope-interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pyopenssl"
@@ -693,7 +729,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pyrxp"
@@ -702,6 +738,27 @@ description = "Python RXP interface - fast validating XML parser"
 category = "main"
 optional = false
 python-versions = ">=3.6, <4"
+
+[[package]]
+name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+toml = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -738,7 +795,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "safe-netrc"
@@ -782,9 +839,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+docs = ["sphinx (>=3.5)", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "furo", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "sphinx-notfound-page (==0.8.3)", "sphinx-hoverxref (<2)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "flake8 (<5)", "pytest-enabler (>=1.3)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
+testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
 
 [[package]]
 name = "setuptools-scm"
@@ -826,7 +883,7 @@ numpy = ">=1.19.0"
 packaging = "*"
 
 [package.extras]
-doc = ["ipython", "numpydoc", "sphinx (>=1.1)", "sphinx-rtd-theme"]
+doc = ["sphinx (>=1.1)", "sphinx-rtd-theme", "numpydoc", "ipython"]
 
 [[package]]
 name = "toml"
@@ -893,8 +950,8 @@ optional = false
 python-versions = ">=3.5.3"
 
 [package.extras]
-doc = ["sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["mypy", "pytest", "typing-extensions"]
+doc = ["sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["pytest", "typing-extensions", "mypy"]
 
 [[package]]
 name = "typing-extensions"
@@ -913,14 +970,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "urllib3-secure-extra", "ipaddress"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "8baead9db3f1423300491deb8b6c518da307b1f467423686a75a71ed8eaa4f4c"
+content-hash = "10e7773f4688a742de901c487a4654c1642e161cd8b2438af8d22e55e649ef1a"
 
 [metadata.files]
 astropy = [
@@ -940,6 +997,9 @@ astropy = [
     {file = "astropy-4.3.1-cp39-cp39-win32.whl", hash = "sha256:dcb6d7e6631d92d5d15b7ae4e0a994829609b09a4e3af2055995187edb8989e3"},
     {file = "astropy-4.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:434ab46e85f5406acc9f2d2084e5e36890abeaf615c8aa71178e835134b64726"},
     {file = "astropy-4.3.1.tar.gz", hash = "sha256:2d3951223b4eb7f368fcad8c8340d27374c5d8e3b635a636275acdb38f35cd51"},
+]
+atomicwrites = [
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 attrs = [
     {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
@@ -1149,6 +1209,7 @@ dqsegdb2 = [
 ]
 dynesty = [
     {file = "dynesty-1.0.1-py2.py3-none-any.whl", hash = "sha256:98e381308f9a280bdb8d186b7dd333edf71583117a9f06605b845541d60dfb5b"},
+    {file = "dynesty-1.0.1-py3.6.egg", hash = "sha256:5fcdfc522d7770ae2f33603b7cb4f4c585bb7f9d1882f6081daa09dcf464af5f"},
     {file = "dynesty-1.0.1.tar.gz", hash = "sha256:ddaeae35d359abb4cbb1c277500acab55b54ef4fb14932caacb4b8a6f719f7af"},
 ]
 emcee = [
@@ -1205,6 +1266,10 @@ igwn-auth-utils = [
     {file = "igwn-auth-utils-0.3.1.tar.gz", hash = "sha256:9698bbd9c46eddf4fe65d157c16a2ee185e4ccf5f98ecc24b08d4bd79378ccae"},
     {file = "igwn_auth_utils-0.3.1-py3-none-any.whl", hash = "sha256:e0ac5433410aaca5916479b3d61ee221235dcb451b05ef2272818a7fde437d41"},
 ]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
 kiwisolver = [
     {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2f5e60fabb7343a836360c4f0919b8cd0d6dbf08ad2ca6b9cf90bf0c76a3c4f6"},
     {file = "kiwisolver-1.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:10ee06759482c78bdb864f4109886dff7b8a56529bc1609d4f1112b93fe6423c"},
@@ -1216,21 +1281,6 @@ kiwisolver = [
     {file = "kiwisolver-1.4.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a68b62a02953b9841730db7797422f983935aeefceb1679f0fc85cbfbd311c32"},
     {file = "kiwisolver-1.4.4-cp310-cp310-win32.whl", hash = "sha256:e92a513161077b53447160b9bd8f522edfbed4bd9759e4c18ab05d7ef7e49408"},
     {file = "kiwisolver-1.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:3fe20f63c9ecee44560d0e7f116b3a747a5d7203376abeea292ab3152334d004"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:e0ea21f66820452a3f5d1655f8704a60d66ba1191359b96541eaf457710a5fc6"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bc9db8a3efb3e403e4ecc6cd9489ea2bac94244f80c78e27c31dcc00d2790ac2"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d5b61785a9ce44e5a4b880272baa7cf6c8f48a5180c3e81c59553ba0cb0821ca"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2dbb44c3f7e6c4d3487b31037b1bdbf424d97687c1747ce4ff2895795c9bf69"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6295ecd49304dcf3bfbfa45d9a081c96509e95f4b9d0eb7ee4ec0530c4a96514"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4bd472dbe5e136f96a4b18f295d159d7f26fd399136f5b17b08c4e5f498cd494"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf7d9fce9bcc4752ca4a1b80aabd38f6d19009ea5cbda0e0856983cf6d0023f5"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78d6601aed50c74e0ef02f4204da1816147a6d3fbdc8b3872d263338a9052c51"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:877272cf6b4b7e94c9614f9b10140e198d2186363728ed0f701c6eee1baec1da"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:db608a6757adabb32f1cfe6066e39b3706d8c3aa69bbc353a5b61edad36a5cb4"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:5853eb494c71e267912275e5586fe281444eb5e722de4e131cddf9d442615626"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:f0a1dbdb5ecbef0d34eb77e56fcb3e95bbd7e50835d9782a45df81cc46949750"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:283dffbf061a4ec60391d51e6155e372a1f7a4f5b15d59c8505339454f8989e4"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-win32.whl", hash = "sha256:d06adcfa62a4431d404c31216f0f8ac97397d799cd53800e9d3efc2fbb3cf14e"},
-    {file = "kiwisolver-1.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:e7da3fec7408813a7cebc9e4ec55afed2d0fd65c4754bc376bf03498d4e92686"},
     {file = "kiwisolver-1.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:62ac9cc684da4cf1778d07a89bf5f81b35834cb96ca523d3a7fb32509380cbf6"},
     {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41dae968a94b1ef1897cb322b39360a0812661dba7c682aa45098eb8e193dbdf"},
     {file = "kiwisolver-1.4.4-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:02f79693ec433cb4b5f51694e8477ae83b3205768a6fb48ffba60549080e295b"},
@@ -1263,16 +1313,6 @@ kiwisolver = [
     {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:787518a6789009c159453da4d6b683f468ef7a65bbde796bcea803ccf191058d"},
     {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da152d8cdcab0e56e4f45eb08b9aea6455845ec83172092f09b0e077ece2cf7a"},
     {file = "kiwisolver-1.4.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:ecb1fa0db7bf4cff9dac752abb19505a233c7f16684c5826d1f11ebd9472b871"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:28bc5b299f48150b5f822ce68624e445040595a4ac3d59251703779836eceff9"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:81e38381b782cc7e1e46c4e14cd997ee6040768101aefc8fa3c24a4cc58e98f8"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2a66fdfb34e05b705620dd567f5a03f239a088d5a3f321e7b6ac3239d22aa286"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:872b8ca05c40d309ed13eb2e582cab0c5a05e81e987ab9c521bf05ad1d5cf5cb"},
-    {file = "kiwisolver-1.4.4-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:70e7c2e7b750585569564e2e5ca9845acfaa5da56ac46df68414f29fea97be9f"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9f85003f5dfa867e86d53fac6f7e6f30c045673fa27b603c397753bebadc3008"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e307eb9bd99801f82789b44bb45e9f541961831c7311521b13a6c85afc09767"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1792d939ec70abe76f5054d3f36ed5656021dcad1322d1cc996d4e54165cef9"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f6cb459eea32a4e2cf18ba5fcece2dbdf496384413bc1bae15583f19e567f3b2"},
-    {file = "kiwisolver-1.4.4-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:36dafec3d6d6088d34e2de6b85f9d8e2324eb734162fba59d2ba9ed7a2043d5b"},
     {file = "kiwisolver-1.4.4.tar.gz", hash = "sha256:d41997519fcba4a1e46eb4a2fe31bc12f0ff957b2b81bac28db24744f333e955"},
 ]
 lalsuite = [
@@ -1442,8 +1482,8 @@ pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
     {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
     {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:408673ed75594933714482501fe97e055a42996087eeca7e5d06e33218d05aa8"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:727dd1389bc5cb9827cbd1f9d40d2c2a1a0c9b32dd2261db522d22a604a6eec9"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},
@@ -1490,6 +1530,14 @@ pillow = [
     {file = "Pillow-9.2.0-pp38-pypy38_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:96b5e6874431df16aee0c1ba237574cb6dff1dcb173798faa6a9d8b399a05d0e"},
     {file = "Pillow-9.2.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:0030fdbd926fb85844b8b92e2f9449ba89607231d3dd597a21ae72dc7fe26927"},
     {file = "Pillow-9.2.0.tar.gz", hash = "sha256:75e636fd3e0fb872693f23ccb8a5ff2cd578801251f3a4f6854c6a5d437d3c04"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -1583,6 +1631,10 @@ pyrxp = [
     {file = "pyRXP-3.0.1-cp39-cp39-win32.whl", hash = "sha256:331a42a4fc067438e9e1997c0a439ddb1f27d1d9d57f33bc3be9e024516e9d4e"},
     {file = "pyRXP-3.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:f02185da19c7e24bead96cdd599177590b91f53ff70ed5c788f218877484cfb5"},
     {file = "pyRXP-3.0.1.tar.gz", hash = "sha256:f5563dee342f329f840380aafccf786b504d6a82e91611defb27f3f51043be9a"},
+]
+pytest = [
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/projects/sandbox/train/pyproject.toml
+++ b/projects/sandbox/train/pyproject.toml
@@ -12,6 +12,9 @@ python = ">=3.8,<3.11"
 "bbhnet.trainer" = {path = "../../../libs/trainer", develop = true}
 "bbhnet.logging" = {path = "../../../libs/logging", develop = true}
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^6.2"
+
 [tool.poetry.scripts]
 train = "train.train:main"
 

--- a/projects/sandbox/train/tests/test_validation.py
+++ b/projects/sandbox/train/tests/test_validation.py
@@ -1,0 +1,80 @@
+import pytest
+import torch
+from train import validation
+
+
+def test_background_recall():
+    metric = validation.BackgroundRecall(10, 10, 3)
+    background = torch.zeros((31,))
+
+    # after pooling, the top 3 values should come
+    # out to 2, 1.5, and 0.8
+    background[3] = 1
+    background[4] = 1.5
+    background[10] = 2
+    background[14] = 0.5
+    background[18] = 0.9
+    background[22] = 0.8
+    background[30] = 3  # this will get trimmed
+
+    signal = torch.arange(0.5, 2.5, 0.1)
+    scores = metric(background, None, signal).cpu().numpy()
+    assert len(scores) == 3
+    assert all([i == j for i, j in zip(scores, metric.values)])
+
+    assert pytest.approx(scores[0], 0.25)
+    assert pytest.approx(scores[1], 0.5)
+    assert pytest.approx(scores[2], 0.85)
+
+
+def test_glitch_recall():
+    metric = validation.GlitchRecall([0.5, 0.75, 1])
+    glitches = torch.arange(11).type(torch.float32)
+    signal = torch.arange(4, 12).type(torch.float32)
+
+    scores = metric(None, glitches, signal).cpu().numpy()
+    assert len(scores) == 3
+    assert all([i == j for i, j in zip(scores, metric.values)])
+
+    assert pytest.approx(scores[0], 7 / 8)
+    assert pytest.approx(scores[1], 4 / 8)
+    assert pytest.approx(scores[2], 1 / 8)
+
+
+def test_make_background():
+    x = torch.arange(2 * 32).reshape(2, 32).type(torch.float32)
+    batched = validation.make_background(x, 10, 5)
+    assert batched.shape == (5, 2, 10)
+
+    for i in range(5):
+        for j in range(2):
+            start = i * 5 + j * 32
+            expected = torch.arange(start, start + 10)
+            assert (batched[i, j] == expected).all().item()
+
+
+def test_make_glitches():
+    background = 2 + torch.arange(2 * 32).reshape(2, 32).type(torch.float32)
+    background = validation.make_background(background, 10, 5)
+
+    glitches = [torch.zeros((9, 12)), torch.ones((11, 12))]
+
+    # put wrong values at the edges to make sure
+    # that these get appropriate sliced out
+    glitches[0][:, [0, -1]] = 1
+    glitches[1][:, [0, -1]] = 0
+
+    dataset = validation.make_glitches(glitches, background, 0.5)
+    assert dataset.shape == (16, 2, 10)
+
+    # first 9 - 4 = 5 should be just H1
+    assert (dataset[:5, 0] == 0).all().item()
+    assert (dataset[:5, 1] != 0).all().item()
+
+    # next 11 - 4 = 7 should be just L1
+    assert (dataset[5:12, 0] != 1).all().item()
+    assert (dataset[5:12, 1] == 1).all().item()
+
+    # remaining (0.5**2) * 16 = 4 should be coincident
+    assert (dataset[12:, 0] == 0).all().item()
+    assert (dataset[12:, 1] == 1).all().item()

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -205,10 +205,10 @@ def main(
     # into one file for simplicity
     background = load_background(hanford_background, livingston_background)
     if valid_frac is not None:
-        background, valid_background = split(background, 1 - valid_frac)
+        background, valid_background = split(background, 1 - valid_frac, -1)
         recorder = Recorder(
             outdir,
-            "recall@spec=1",
+            "recall@spec=1.0",
             kernel_length=4,
             stride=2,
             sample_rate=sample_rate,

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -4,7 +4,7 @@ from typing import Optional
 import h5py
 import numpy as np
 from train.utils import prepare_augmentation, split
-from train.validation import make_validation_dataset
+from train.validation import Recorder, Validator
 
 from bbhnet.architectures import Preprocessor
 from bbhnet.data.dataloader import BBHInMemoryDataset
@@ -34,10 +34,10 @@ def load_background(*backgrounds: Path):
 @trainify
 def main(
     # paths and environment args
-    hanford_background: str,
-    livingston_background: str,
-    glitch_dataset: str,
-    waveform_dataset: str,
+    hanford_background: Path,
+    livingston_background: Path,
+    glitch_dataset: Path,
+    waveform_dataset: Path,
     outdir: Path,
     logdir: Path,
     # data generation args
@@ -57,6 +57,7 @@ def main(
     # validation args
     valid_frac: Optional[float] = None,
     valid_stride: Optional[float] = None,
+    early_stop: Optional[int] = None,
     # misc args
     device: str = "cpu",
     verbose: bool = False,
@@ -204,9 +205,32 @@ def main(
     # into one file for simplicity
     background = load_background(hanford_background, livingston_background)
     if valid_frac is not None:
-        background, valid_background = split(background, 1 - valid_frac, 1)
-        valid_injector.fit(H1=background[0], L1=background[1])
-        valid_waveforms, _ = valid_injector.sample(-1)
+        background, valid_background = split(background, 1 - valid_frac)
+        recorder = Recorder(
+            outdir,
+            "recall@spec=1",
+            kernel_length=4,
+            stride=2,
+            sample_rate=sample_rate,
+            topk=5,
+            specs=[0.75, 0.9, 1],
+            early_stop=early_stop,
+            checkpoint_every=5,
+        )
+        validator = Validator(
+            recorder,
+            background=valid_background,
+            glitches=valid_glitches,
+            injector=valid_injector,
+            kernel_length=kernel_length,
+            stride=valid_stride,
+            sample_rate=sample_rate,
+            batch_size=4 * batch_size,
+            glitch_frac=glitch_prob,
+            device=device,
+        )
+    else:
+        validator = None
 
     # fit our waveform injector to this background
     # to facilitate the SNR remapping
@@ -241,21 +265,4 @@ def main(
     # move eveyrthing to the desired device
     preprocessor.whitener.fit(background)
     preprocessor.whitener.to(device)
-
-    # deterministic validation glitch sampler
-    if valid_frac is not None:
-        valid_dataset = make_validation_dataset(
-            valid_background,
-            valid_glitches,
-            valid_waveforms,
-            kernel_length=kernel_length,
-            stride=valid_stride,
-            sample_rate=sample_rate,
-            batch_size=batch_size * 8,
-            glitch_frac=glitch_prob,
-            device=device,
-        )
-    else:
-        valid_dataset = None
-
-    return train_dataset, valid_dataset, preprocessor
+    return train_dataset, validator, preprocessor

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -240,7 +240,7 @@ def main(
         # build a couple validation metrics to evaluate during training
         background_recall = BackgroundRecall(
             kernel_size=int(4 / valid_stride),
-            stride=int(2 / valid_stride),
+            stride=int(4 / valid_stride),
             k=5,
         )
         glitch_recall = GlitchRecall(specs=[0.75, 0.9, 1])

--- a/projects/sandbox/train/train/utils.py
+++ b/projects/sandbox/train/train/utils.py
@@ -11,7 +11,7 @@ from bbhnet.data.distributions import Cosine, LogNormal, Uniform
 from bbhnet.data.glitch_sampler import GlitchSampler
 from bbhnet.data.waveform_injection import BBHNetWaveformInjection
 
-Tensor = TypeVar("T", np.ndarray, torch.Tensor)
+Tensor = TypeVar("Tensor", np.ndarray, torch.Tensor)
 
 
 class MultiInputSequential(torch.nn.Sequential):
@@ -94,7 +94,7 @@ def prepare_augmentation(
                 dec=f["dec"][slc],
                 psi=f["psi"][slc],
                 phi=f["ra"][slc],  # no geocent_time recorded, so just use ra
-                snr=lambda N: torch.ones((N,)) * mean_snr,
+                snr=None,
                 sample_rate=sample_rate,
                 highpass=highpass,
                 trigger_offset=0,

--- a/projects/sandbox/train/train/validation.py
+++ b/projects/sandbox/train/train/validation.py
@@ -1,42 +1,163 @@
 import logging
+import pickle
+from dataclasses import dataclass
 from math import ceil
-from typing import Iterable
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional, Sequence
 
 import numpy as np
 import torch
 from train.utils import split
 
+if TYPE_CHECKING:
+    from bbhnet.data.waveform_injection import BBHNetWaveformInjection
 
-def make_validation_dataset(
-    background: np.ndarray,
-    glitches: Iterable[np.ndarray],
-    waveforms: torch.Tensor,
-    kernel_length: float,
-    stride: float,
-    sample_rate: float,
-    batch_size: int,
-    glitch_frac: float,
-    device: str,
-):
-    # redefine args in terms of number of samples, infer
-    # some downstream parameters that depend on them
-    kernel_size = int(kernel_length * sample_rate)
-    stride_size = int(stride * sample_rate)
-    num_kernels = (background.shape[-1] - kernel_size) // stride_size + 1
-    num_kernels = int(num_kernels)
-    num_ifos = len(background)
-    if len(glitches) != num_ifos:
-        raise ValueError(
-            "Number of glitch tensors {} doesn't match number "
-            "of interferometers {}".format(len(glitches), num_ifos)
+
+@dataclass
+class Metric:
+    @property
+    def fields(self):
+        raise NotImplementedError
+
+    def __call__(self):
+        raise NotImplementedError
+
+
+@dataclass
+class BackgroundRecall(Metric):
+    kernel_size: int
+    stride: int
+    k: int = 5
+
+    @property
+    def fields(self):
+        return [f"recall@k={i+1}" for i in range(self.k)]
+
+    def __call__(self, background, signal):
+        background = torch.nn.functional.max_pool1d(
+            background, kernel_size=self.kernel_size, stride=self.stride
         )
+        topk = torch.topk(background, self.k)
+        recall = (signal.unsqueeze(1) >= topk).sum(0) / len(signal)
+        return dict(zip(self.fields, recall.cpu().numpy()))
 
-    # 1. Create pre-computed kernels of pure background
-    # slice our background so that it has an integer number of
-    # windows, then add dummy dimensions since unfolding only
-    # works on 4D tensors
+
+@dataclass
+class GlitchRecall(Metric):
+    specs: Sequence[float]
+
+    def __post_init__(self):
+        for spec in self.specs:
+            assert 0 <= spec <= 1
+        self.specs = torch.Tensor(self.specs)
+
+    @property
+    def fields(self):
+        return [f"recall@spec={spec}" for spec in self.specs]
+
+    def __call__(self, glitches, signal):
+        qs = torch.quantile(glitches.unsqueeze(1), self.specs)
+        recall = (signal.unsqueeze(1) >= qs).sum(0) / len(signal)
+        return dict(zip(self.fields, recall.cpu().numpy()))
+
+
+@dataclass
+class Recorder:
+    logdir: Path
+    monitor: str
+    kernel_length: int
+    stride: int
+    sample_rate: float
+    topk: int = 5
+    specs: Sequence[float] = [0.75, 0.9, 1]
+    early_stop: Optional[int] = None
+    checkpoint_every: Optional[int] = None
+
+    def __post_init__(self):
+        self.background = BackgroundRecall(
+            int(self.kernel_length * self.sample_rate),
+            int(self.stride * self.sample_rate),
+            self.topk,
+        )
+        self.glitch = GlitchRecall(self.specs)
+
+        fields = self.background.fields + self.glitch.fields
+        if self.monitor not in fields:
+            raise ValueError(
+                f"Monitor field {self.monitor} not in metric fields {fields}"
+            )
+        self.history = {i: [] for i in fields + ["train_loss"]}
+
+        if self.checkpoint_every is not None:
+            (self.logdir / "checkpoints").mkdir(parents=True, exist_ok=True)
+
+        self.best = 0
+        self._i = 0
+
+    def record(
+        self,
+        model: torch.nn.Module,
+        train_loss: float,
+        background: torch.Tensor,
+        glitches: torch.Tensor,
+        signal: torch.Tensor,
+    ):
+        train_loss = train_loss
+        metrics = {"train_loss": train_loss}
+        bckgrd_recall = self.background(background, signal)
+        glitch_recall = self.glitch(glitches, signal)
+
+        metrics.update(bckgrd_recall)
+        metrics.update(glitch_recall)
+
+        msg = f"Train loss: {train_loss}"
+        msg += "\nRecall vs. background @:"
+        for field in self.background.fields:
+            value = metrics[field]
+            msg += "\n" + field.split("@")[1] + f": {value:0.3f}"
+        msg += "\nRecall vs. glitches @:"
+        for field in self.glitch.fields:
+            value = metrics[field]
+            msg += "\n" + field.split("@")[1] + f": {value:0.3f}"
+        logging.info(msg)
+
+        return self.checkpoint(model, metrics)
+
+    def checkpoint(
+        self, model: torch.nn.Module, metrics: Dict[str, float]
+    ) -> bool:
+        self._i += 1
+        for key, val in metrics:
+            self.history[key].append(val)
+
+        if (
+            self.checkpoint_every is not None
+            and not self._i % self.checkpoint_every
+        ):
+            epoch = str(self._i).zfill(4)
+            fname = self.logdir / "checkpoints" / f"epoch_{epoch}.pt"
+            torch.save(model.state_dict(), fname)
+
+        if metrics[self.monitor] > self.best:
+            fname = self.logdir / "weights.pt"
+            torch.save(model.state_dict(), fname)
+            self._since_last = 0
+        elif self.early_stop is not None:
+            self._since_last += 1
+            if self._since_last >= self.early_stop:
+                return True
+        return False
+
+
+def make_background(
+    background: np.ndarray, kernel_size: int, stride_size: int
+) -> torch.Tensor:
+    num_ifos, size = background.shape
+    num_kernels = (size - kernel_size) // stride_size + 1
+    num_kernels = int(num_kernels)
+
     background = background[:, : num_kernels * stride_size + kernel_size]
-    background = torch.Tensor(background).view(1, num_ifos, 1, -1)
+    background = torch.Tensor(background)[None, :, None]
 
     # fold out into windows up front
     background = torch.nn.functional.unfold(
@@ -47,11 +168,21 @@ def make_validation_dataset(
     # unfold op orders things. Don't worry about it
     background = background.reshape(num_ifos, num_kernels, kernel_size)
     background = background.transpose(1, 0)
+    return background
 
-    # 2. Copy these windows and insert glitches into the
-    # interferometer channels to make a glitch dataset
-    # begin by setting aside the first `glitch_frac` of
-    # each channel to be placed in coincident kernels
+
+def make_glitches(
+    glitches: Sequence[np.ndarray],
+    background: torch.Tensor,
+    kernel_size: int,
+    glitch_frac: float,
+) -> torch.Tensor:
+    if len(glitches) != background.size(1):
+        raise ValueError(
+            "Number of glitch tensors {} doesn't match number "
+            "of interferometers {}".format(len(glitches), background.size(1))
+        )
+
     h1_glitches, l1_glitches = map(torch.Tensor, glitches)
     num_h1, num_l1 = len(h1_glitches), len(l1_glitches)
     num_glitches = num_h1 + num_l1
@@ -65,42 +196,92 @@ def make_validation_dataset(
 
     # if we need to create duplicates of some of our
     # background to make this work, figure out how many
-    repeats = ceil(num_glitches / len(background))
-    glitch_background = background.repeat(repeats, 1, 1)
-    glitch_background = glitch_background[:num_glitches]
+    background = repeat(background, num_glitches)
 
     # now insert the glitches
     start = h1_glitches.shape[-1] // 2 - kernel_size // 2
-    stop = start + kernel_size
-    glitch_background[:num_h1, 0] = h1_glitches[:, start:stop]
-    glitch_background[num_h1:-num_coinc, 1] = l1_glitches[:, start:stop]
-    glitch_background[-num_coinc:] = coinc[:, :, start:stop]
+    slc = slice(start, start + kernel_size)
 
-    # 3. create a tensor of background with waveforms injected
-    repeats = ceil(len(waveforms) / len(background))
-    waveform_background = background.repeat(repeats, 1, 1)
-    waveform_background = waveform_background[: len(waveforms)]
+    background[:num_h1, 0] = h1_glitches[:, slc]
+    background[num_h1:-num_coinc, 1] = l1_glitches[:, slc]
+    background[-num_coinc:] = coinc[:, :, slc]
 
-    start = waveforms.shape[-1] // 2 - kernel_size // 2
-    stop = start + kernel_size
-    waveform_background += waveforms[:, :, start:stop]
+    return background
 
-    # concatenate everything into a single tensor
-    # and create the associated labels
-    X = torch.concat([background, glitch_background, waveform_background])
-    y = torch.zeros((len(X), 1))
-    y[-len(waveform_background) :] = 1
 
-    logging.info("Performing validation on:")
-    logging.info(f"    {len(background)} windows of background")
-    logging.info(f"    {num_h1} H1 glitches")
-    logging.info(f"    {num_l1} L1 glitches")
-    logging.info(f"    {num_coinc} coincident glitches")
-    logging.info(f"    {len(waveforms)} injected waveforms")
-    dataset = torch.utils.data.TensorDataset(X, y)
-    return torch.utils.data.DataLoader(
-        dataset,
-        pin_memory=True,
-        batch_size=batch_size,
-        pin_memory_device=device,
-    )
+def repeat(X: torch.Tensor, max_num: int):
+    repeats = ceil(len(X) / max_num)
+    X = X.repeat(repeats, 1, 1)
+    return X[:max_num]
+
+
+class Validator:
+    def __init__(
+        self,
+        recorder: Recorder,
+        background: np.ndarray,
+        glitches: Sequence[np.ndarray],
+        injector: "BBHNetWaveformInjection",
+        kernel_length: float,
+        stride: float,
+        sample_rate: float,
+        batch_size: int,
+        glitch_frac: float,
+        device: str,
+    ) -> None:
+        self.device = device
+        self.recorder = recorder
+
+        kernel_size = int(kernel_length * sample_rate)
+        stride_size = int(stride * sample_rate)
+
+        # create a datset of pure background
+        background = make_background(background, kernel_size, stride_size)
+        self.background_loader = self.make_loader(background, batch_size)
+
+        # now repliate that dataset but with glitches inserted
+        # into either or both interferometer channels
+        glitch_background = make_glitches(
+            glitches, background, kernel_size, glitch_frac
+        )
+        self.glitch_loader = self.make_loader(glitch_background, batch_size)
+
+        # 3. create a tensor of background with waveforms injected
+        waveforms = injector.sample(-1)
+        signal_background = repeat(background, len(waveforms))
+
+        start = waveforms.shape[-1] // 2 - kernel_size // 2
+        stop = start + kernel_size
+        signal_background += waveforms[:, :, start:stop]
+        self.signal_loader = self.make_loader(signal_background, batch_size)
+
+    def make_loader(self, X: torch.Tensor, batch_size: int):
+        dataset = torch.utils.data.Dataset(X)
+        return torch.utils.data.DataLoader(
+            dataset,
+            pin_memory=True,
+            batch_size=batch_size,
+            pin_memory_device=self.device,
+        )
+
+    def get_predictions(self, loader, model):
+        preds = []
+        for (X,) in loader:
+            X = X.to(self.device)
+            y_hat = model(X)[:, 0]
+            preds.append(y_hat)
+        return torch.cat(preds)
+
+    @torch.no_grad
+    def __call__(self, model: torch.nn.Module, train_loss: float) -> bool:
+        background_preds = self.get_predictions(self.background_loader, model)
+        glitch_preds = self.get_predictions(self.glitch_loader, model)
+        signal_preds = self.get_predictions(self.signal_loader, model)
+
+        return self.recorder.record(
+            model, train_loss, background_preds, glitch_preds, signal_preds
+        )
+
+    def save(self):
+        with open(self.recorder.logdir / "history.pkl", "wb") as f:
+            pickle.dump(self.recorder.history, f)


### PR DESCRIPTION
Implement measurements of recall (fraction of signals recovered) vs. background and glitch datasets separately. Closes #41 , closes #170 . Re-creation of #221 but with the git history better aligned.

For background, outputs are pooled across adjustable windows at an adjustable stride to simulate test-time clustering, and recall is measured using thresholds from the top `k` background "events".

For glitches, recall is measured using thresholds from adjustable specificity levels (fraction of glitches correctly classified at a given threshold).

Monitoring (for early stopping and model selection) can be performed against any threshold for either metric. Checkpointing at a specified cadence has been added as well.

- [x] Add `Recorder` and `Validator` parameters to `train:main` function definition
- [x] Add tests
- [x] Fix `sample_rate` used for background pooling to be `1 / stride`