### PR TITLE
fixing export tests

### DIFF
--- a/projects/sandbox/export/tests/test_export.py
+++ b/projects/sandbox/export/tests/test_export.py
@@ -194,7 +194,7 @@ def test_export_for_shapes(
     get_network_weights(num_ifos, sample_rate, kernel_length, weights)
 
     # test fully from scratch behavior
-    if kernel_length < (batch_size / inference_sampling_rate):
+    if (kernel_length * inference_sampling_rate) <= 1:
         context = pytest.raises(ValueError)
     else:
         context = nullcontext()


### PR DESCRIPTION
The export tests were breaking under the newest version of hermes which changed the conditions under which a given `inference_sampling_rate` and `kernel_length` combo could be exported together. This fixes that issue.