### PR TITLE
Adding normalizer check and accelerating distribution clustering

### DIFF
--- a/libs/analysis/bbhnet/analysis/normalizers.py
+++ b/libs/analysis/bbhnet/analysis/normalizers.py
@@ -36,7 +36,7 @@ class GaussianNormalizer:
         sqs = boxcar_filter(y**2, self.norm_size)
         scales = np.sqrt(sqs - shifts**2)
         if (scales == 0).any():
-            raise ValueError("Encountered 0 scale values")
+            raise ValueError("Encountered 0s in scale parameter")
 
         self.shifts = shifts
         self.scales = scales

--- a/libs/analysis/bbhnet/analysis/normalizers.py
+++ b/libs/analysis/bbhnet/analysis/normalizers.py
@@ -35,6 +35,8 @@ class GaussianNormalizer:
         shifts = boxcar_filter(y, self.norm_size)
         sqs = boxcar_filter(y**2, self.norm_size)
         scales = np.sqrt(sqs - shifts**2)
+        if (scales == 0).any():
+            raise ValueError("Encountered 0 scale values")
 
         self.shifts = shifts
         self.scales = scales

--- a/libs/analysis/tests/conftest.py
+++ b/libs/analysis/tests/conftest.py
@@ -13,9 +13,9 @@ def boxcar_integration_test_fn():
     def _test_fn(window_size, array):
         for i, value in enumerate(array):
             if i < window_size:
-                expected = sum(range(i + 1)) / window_size
+                expected = sum(range(i + 2)) / window_size
             else:
-                expected = (i + 1 + i - window_size) / 2
+                expected = (i + 3 + i - window_size) / 2
             assert isclose(value, expected, rel_tol=1e-9)
 
     return _test_fn

--- a/libs/analysis/tests/distributions/test_cluster.py
+++ b/libs/analysis/tests/distributions/test_cluster.py
@@ -20,7 +20,8 @@ def test_cluster_distribution():
 
     distribution.fit((y, t), shifts)
     assert distribution.Tb == 3
-    assert (distribution.events == [2]).all()
+    assert len(distribution.events) == 1
+    assert (distribution.events == 2).all()
     assert len(distribution.shifts) == len(distribution.events)
 
     # expect no clustering

--- a/libs/analysis/tests/test_analysis.py
+++ b/libs/analysis/tests/test_analysis.py
@@ -18,7 +18,7 @@ def sample_rate(request):
 
 @pytest.fixture
 def y(length, sample_rate):
-    return np.arange(int(length * sample_rate))
+    return np.arange(int(length * sample_rate)) + 1
 
 
 @pytest.fixture

--- a/libs/analysis/tests/test_integrators.py
+++ b/libs/analysis/tests/test_integrators.py
@@ -4,7 +4,7 @@ from bbhnet.analysis.integrators import boxcar_filter
 
 
 def test_boxcar_filter(window_size, boxcar_integration_test_fn):
-    y = np.arange(1000)
+    y = np.arange(1000) + 1
     result = boxcar_filter(y, window_size)
     assert len(result) == len(y)
 

--- a/libs/analysis/tests/test_normalizers.py
+++ b/libs/analysis/tests/test_normalizers.py
@@ -29,12 +29,18 @@ def test_gaussian_normalizer(
     assert normalizer.norm_size == int(norm_size)
     norm_size = int(norm_size)
 
+    # test to make sure we enforce fitting
     y = np.arange(1000)
     with pytest.raises(ValueError) as exc_info:
         normalizer(y, window_size)
     assert str(exc_info.value) == "GaussianNormalizer hasn't been fit"
 
-    normalizer.fit(y)
+    # test to make sure we don't allow 0 scale values
+    with pytest.raises(ValueError) as exc_info:
+        normalizer.fit(y)
+    assert str(exc_info.value) == "Encountered 0 scale values"
+
+    normalizer.fit(y + 1)
     boxcar_integration_test_fn(norm_size, normalizer.shifts)
 
     # check the scale values manually
@@ -43,17 +49,17 @@ def test_gaussian_normalizer(
         if i < norm_size:
             mu = normalizer.shifts[i]
             expected = (norm_size - i - 1) * mu**2
-            expected += sum([(j - mu) ** 2 for j in range(i + 1)])
+            expected += sum([(j + 1 - mu) ** 2 for j in range(i + 1)])
             expected /= norm_size
         else:
             expected = (norm_size**2 - 1) / 12
-        assert isclose(value, expected, rel_tol=1e-9)
+        assert isclose(value, expected, rel_tol=1e-9), i
 
     with pytest.raises(ValueError) as exc_info:
         normalizer(y[:-1], window_size)
     assert str(exc_info.value).startswith("Can't normalize")
 
-    normalized = normalizer(y, window_size)
+    normalized = normalizer(y + 1, window_size)
     assert len(normalized) == (len(y) - window_size - norm_size)
 
     # all the normalized values should be equal to a constant

--- a/libs/analysis/tests/test_normalizers.py
+++ b/libs/analysis/tests/test_normalizers.py
@@ -38,7 +38,7 @@ def test_gaussian_normalizer(
     # test to make sure we don't allow 0 scale values
     with pytest.raises(ValueError) as exc_info:
         normalizer.fit(y)
-    assert str(exc_info.value) == "Encountered 0 scale values"
+    assert str(exc_info.value) == "Encountered 0s in scale parameter"
 
     normalizer.fit(y + 1)
     boxcar_integration_test_fn(norm_size, normalizer.shifts)


### PR DESCRIPTION
Closes #235 and speeds up clustering by a factor of ~20 by jumping peak values rather than doing comparisons for every value in the array