### PR TITLE
update default priors

### DIFF
--- a/libs/priors/bbhnet/priors/priors.py
+++ b/libs/priors/bbhnet/priors/priors.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Sequence, Tuple
 
+import astropy.cosmology as cosmo
 import h5py
 import numpy as np
 from bilby.core.prior import (
@@ -12,11 +13,7 @@ from bilby.core.prior import (
     Sine,
     Uniform,
 )
-from bilby.gw.prior import (
-    BBHPriorDict,
-    UniformComovingVolume,
-    UniformSourceFrame,
-)
+from bilby.gw.prior import BBHPriorDict, UniformSourceFrame
 
 # Unit names
 msun = r"$M_{\odot}$"
@@ -108,7 +105,9 @@ def nonspin_bbh() -> BBHPriorDict:
     prior["mass_1"] = Uniform(5, 100, unit=msun)
     prior["mass_2"] = Uniform(5, 100, unit=msun)
     prior["mass_ratio"] = Constraint(0, 1)
-    prior["redshift"] = UniformSourceFrame(0, 0.5, unit=mpc, name="redshift")
+    prior["redshift"] = UniformSourceFrame(
+        0, 0.5, unit=mpc, name="redshift", cosmology=cosmo.Planck15
+    )
     prior["psi"] = 0
     prior["a_1"] = 0
     prior["a_2"] = 0
@@ -120,12 +119,33 @@ def nonspin_bbh() -> BBHPriorDict:
     return prior
 
 
+def spin_bbh() -> BBHPriorDict:
+    prior = uniform_extrinsic()
+    prior["mass_1"] = Uniform(5, 100, unit=msun)
+    prior["mass_2"] = Uniform(5, 100, unit=msun)
+    prior["mass_ratio"] = Constraint(0, 1)
+    prior["redshift"] = UniformSourceFrame(
+        0, 0.5, unit=mpc, name="redshift", cosmology=cosmo.Planck15
+    )
+    prior["psi"] = 0
+    prior["a_1"] = Uniform(0, 0.998)
+    prior["a_2"] = Uniform(0, 0.998)
+    prior["tilt_1"] = Sine(unit=rad)
+    prior["tilt_2"] = Sine(unit=rad)
+    prior["phi_12"] = Uniform(0, 2 * np.pi)
+    prior["phi_jl"] = 0
+
+    return prior
+
+
 def end_o3_ratesandpops() -> BBHPriorDict:
     prior = uniform_extrinsic()
     prior["mass_1"] = PowerLaw(alpha=-2.35, minimum=2, maximum=100, unit=msun)
     prior["mass_2"] = PowerLaw(alpha=1, minimum=2, maximum=100, unit=msun)
     prior["mass_ratio"] = Constraint(0.02, 1)
-    prior["redshift"] = UniformComovingVolume(0, 2, unit=mpc, name="redshift")
+    prior["redshift"] = UniformSourceFrame(
+        0, 2, unit=mpc, name="redshift", cosmology=cosmo.Planck15
+    )
     prior["psi"] = 0
     prior["a_1"] = Uniform(0, 0.998)
     prior["a_2"] = Uniform(0, 0.998)

--- a/libs/priors/bbhnet/priors/priors.py
+++ b/libs/priors/bbhnet/priors/priors.py
@@ -179,8 +179,13 @@ def gaussian_masses(m1: float, m2: float, sigma: float = 2):
     prior_dict = BBHPriorDict()
     prior_dict["mass_1"] = Gaussian(name="mass_1", mu=m1, sigma=sigma)
     prior_dict["mass_2"] = Gaussian(name="mass_2", mu=m1, sigma=sigma)
+    prior_dict["mass_ratio"] = Constraint(0, 1)
     prior_dict["luminosity_distance"] = UniformSourceFrame(
-        name="luminosity_distance", minimum=100, maximum=3000, unit="Mpc"
+        name="luminosity_distance",
+        minimum=100,
+        maximum=3000,
+        unit="Mpc",
+        cosmology=cosmo.Planck15,
     )
     prior_dict["dec"] = Cosine(name="dec")
     prior_dict["ra"] = Uniform(

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -32,7 +32,7 @@ inference_batch_size = 128
 minimum_frequency = 20
 reference_frequency = 50
 highpass = 32
-prior = "bbhnet.priors.priors.nonspin_bbh"
+timeslide_prior = "bbhnet.priors.priors.end_o3_ratesandpops"
 fduration = 1
 valid_frac = 0.25
 
@@ -79,7 +79,7 @@ reference_frequency = "${base.reference_frequency}"
 datadir = "${base.datadir}"
 logdir = "${base.logdir}"
 n_samples = 10000
-prior = "${base.prior}"
+prior = "bbhnet.priors.priors.spin_bbh""
 sample_rate = "${base.sample_rate}" 
 waveform_duration = 8
 force_generation = "${base.force_generation}"
@@ -177,7 +177,7 @@ shifts = [0, 1]
 n_slides = 10
 
 # injection parameters
-prior = "${base.prior}"
+prior = "bbhnet.priors.priors.end_o3_ratesandpops"
 minimum_frequency = "${base.minimum_frequency}"
 reference_frequency = "${base.reference_frequency}"
 highpass = "${base.highpass}"
@@ -221,8 +221,8 @@ log_file = "${base.logdir}/analyze.log"
 verbose = false
 
 [tool.typeo.scripts.vizapp]
-source_prior = "bbhnet.priors.priors.nonspin_bbh"
-timeslides_results_dir = "${base.basedir}/timeslide_injections/"
+source_prior = "${base.timeslide_prior}"
+timeslides_results_dir = "${base.basedir}/timeslide_injections-epoch=080/"
 timeslides_strain_dir = "${base.datadir}/timeslide_injections"
 ifos = "${base.ifos}"
 start = "${base.train_stop}"
@@ -233,5 +233,5 @@ train_data_dir = "${base.datadir}"
 sample_rate = "${base.sample_rate}"
 fduration = "${base.fduration}"
 valid_frac = "${base.valid_frac}"
-logdir = "${base.basedir}"
+logdir = "./" #"${base.basedir}"
 verbose = true


### PR DESCRIPTION
- Hard codes `Planck15` cosmology for all of our priors. (Should think about best way to add this to the config)
- Adds `spin_bbh` prior that includes the spin priors from `end_o3_ratesandpops` (i.e allows for non zero spins)
- Makes `spin_bbh` the default for generating training waveforms
- Makes `end_o3_ratesandpops` the default for generating timeslide injections