### PR TITLE
FP16 inference

### DIFF
--- a/libs/architectures/bbhnet/architectures/preprocessor.py
+++ b/libs/architectures/bbhnet/architectures/preprocessor.py
@@ -17,9 +17,7 @@ class Preprocessor(torch.nn.Module):
         self,
         num_ifos: int,
         sample_rate: float,
-        kernel_length: float,
         fduration: Optional[float] = None,
-        highpass: Optional[float] = None,
     ) -> None:
         super().__init__()
         self.whitener = Whitening(

--- a/libs/architectures/bbhnet/architectures/resnet.py
+++ b/libs/architectures/bbhnet/architectures/resnet.py
@@ -55,10 +55,10 @@ class ChannelNorm(torch.nn.Module):
         # roll the mean and variance into the
         # weight and bias so that we have to do
         # fewer computations along the full time axis
-        var = (sq_mean - mean**2 + self.eps) ** 0.5
-        weight = self.weight / var
-        bias = self.bias - weight * mean
-        return bias + x * weight
+        std = (sq_mean - mean**2 + self.eps) ** 0.5
+        scale = self.weight / std
+        shift = self.bias - scale * mean
+        return shift + x * scale
 
 
 def get_norm_layer(groups: Optional[int] = None) -> nn.Module:

--- a/libs/architectures/bbhnet/architectures/resnet.py
+++ b/libs/architectures/bbhnet/architectures/resnet.py
@@ -44,7 +44,9 @@ class ChannelNorm(torch.nn.Module):
         # reshape back to full channel dimension
         if self.num_groups != self.num_channels:
             mean = torch.stack([mean, sq_mean], dim=1)
-            mean = mean.reshape(-1, 2, self.num_group, self.channels_per_group)
+            mean = mean.reshape(
+                -1, 2, self.num_groups, self.channels_per_group
+            )
             mean = mean.mean(-1, keepdims=True)
             mean = mean.expand(-1, -1, -1, self.channels_per_group)
             mean = mean.reshape(-1, 2, self.num_channels, 1)

--- a/libs/architectures/bbhnet/architectures/resnet.py
+++ b/libs/architectures/bbhnet/architectures/resnet.py
@@ -11,14 +11,59 @@ import torch.nn as nn
 from torch import Tensor
 
 
-def get_norm_layer(groups: int) -> nn.Module:
-    class GroupNorm(nn.GroupNorm):
+class ChannelNorm(torch.nn.Module):
+    def __init__(
+        self,
+        num_channels: int,
+        num_groups: Optional[int] = None,
+        eps: float = 1e-5,
+    ):
+        super().__init__()
+        num_groups = num_groups or num_channels
+        if num_channels % num_groups:
+            raise ValueError("num_groups must be a factor of num_channels")
+
+        self.num_channels = num_channels
+        self.num_groups = num_groups
+        self.channels_per_group = self.num_channels // self.num_groups
+        self.eps = eps
+
+        shape = (self.num_channels, 1)
+        self.weight = torch.nn.Parameter(torch.ones(shape))
+        self.bias = torch.nn.Parameter(torch.zeros(shape))
+
+    def forward(self, x):
+        keepdims = self.num_groups == self.num_channels
+
+        # compute group variance via the E[x**2] - E**2[x] trick
+        mean = x.mean(-1, keepdims=keepdims)
+        sq_mean = (x**2).mean(-1, keepdims=keepdims)
+
+        # if we have groups, do some reshape magic
+        # to calculate group level stats then
+        # reshape back to full channel dimension
+        if self.num_groups != self.num_channels:
+            mean = torch.stack([mean, sq_mean], dim=1)
+            mean = mean.reshape(-1, 2, self.num_group, self.channels_per_group)
+            mean = mean.mean(-1, keepdims=True)
+            mean = mean.expand(-1, -1, -1, self.channels_per_group)
+            mean = mean.reshape(-1, 2, self.num_channels, 1)
+            mean, sq_mean = mean[:, 0], mean[:, 1]
+
+        # roll the mean and variance into the
+        # weight and bias so that we have to do
+        # fewer computations along the full time axis
+        var = (sq_mean - mean**2 + self.eps) ** 0.5
+        weight = self.weight / var
+        bias = self.bias - weight * mean
+        return bias + x * weight
+
+
+def get_norm_layer(groups: Optional[int] = None) -> nn.Module:
+    class GroupNorm(ChannelNorm):
         def __init__(self, num_channels: int) -> None:
-            if groups == -1:
-                num_groups = num_channels
-            else:
-                num_groups = min(num_channels, groups)
-            super().__init__(num_groups, num_channels)
+            num_groups = None if groups is None else min(num_channels, groups)
+            super().__init__(num_channels, num_groups)
 
     return GroupNorm
 
@@ -251,7 +296,7 @@ class ResNet(nn.Module):
         width_per_group: int = 64,
         # TODO: use Literal["stride", "dilation"] once typeo fix is in
         stride_type: Optional[List[str]] = None,
-        norm_groups: int = -1,
+        norm_groups: Optional[int] = None,
     ) -> None:
         super().__init__()
         self._norm_layer = get_norm_layer(norm_groups)

--- a/projects/sandbox/export/export.py
+++ b/projects/sandbox/export/export.py
@@ -132,7 +132,7 @@ def export(
 
     # do the same for preprocessor
     try:
-        preproc = repo.models["preprocessor"]
+        preproc = repo.models["preproc"]
     except KeyError:
         preproc = repo.add("preproc", platform=platform)
 

--- a/projects/sandbox/export/tests/test_export.py
+++ b/projects/sandbox/export/tests/test_export.py
@@ -354,7 +354,11 @@ def test_export_for_scaling(
         p = repo_dir / "dummy_file.txt"
         p.write_text("dummy text")
 
-    def run_export(instances=bbhnet_instances, clean=clean):
+    def run_export(
+        bbhnet_instances=bbhnet_instances,
+        preproc_instances=preproc_instances,
+        clean=clean,
+    ):
         export(
             architecture,
             str(repo_dir),
@@ -366,8 +370,8 @@ def test_export_for_scaling(
             fduration=1,
             weights=weights,
             streams_per_gpu=streams_per_gpu,
-            bbhnet_instances=instances,
-            preproc_instances=instances,
+            bbhnet_instances=bbhnet_instances,
+            preproc_instances=preproc_instances,
             clean=clean,
         )
 
@@ -399,9 +403,12 @@ def test_export_for_scaling(
 
     # now make sure if we change the scale
     # we get another version and the config changes
-    run_export(instances=3, clean=False)
+    run_export(
+        bbhnet_instances=3, preproc_instances=preproc_instances, clean=False
+    )
     validate_repo(
-        expected_instances=3,
+        expected_bbhnet_instances=3,
+        expected_preproc_instances=preproc_instances,
         expected_snapshots=streams_per_gpu,
         expected_versions=2 if clean else 3,
         expected_num_ifos=num_ifos,
@@ -428,7 +435,7 @@ def test_export_for_scaling(
     assert str(exc_info.value).endswith("model 'bbhnet'")
 
     # ensure that bbhnet got exported before things
-    # went wrong with thet ensemble. TODO: this is
+    # went wrong with the ensemble. TODO: this is
     # actually probably undesirable behavior, but I'm
     # not sure the best way to handle it elegantly in
     # the export function. I guess a try-catch on the
@@ -436,7 +443,8 @@ def test_export_for_scaling(
     # bbhnet version if things go wrong?
     shutil.rmtree(repo_dir / "bbbhnet")
     validate_repo(
-        expected_instances=bbhnet_instances,
+        expected_bbhnet_instances=bbhnet_instances,
+        expected_preproc_instances=preproc_instances,
         expected_snapshots=streams_per_gpu,
         expected_versions=1,
         expected_num_ifos=num_ifos,

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -37,7 +37,7 @@ testing_prior = "bbhnet.priors.priors.end_o3_ratesandpops"
 fduration = 1
 valid_frac = 0.25
 cosmology = "bbhnet.priors.cosmologies.planck"
-streams_per_gpu = 1
+streams_per_gpu = 3
 
 [tool.typeo.scripts.generate-background]
 datadir = "${base.datadir}"
@@ -204,7 +204,7 @@ batch_size = "${base.inference_batch_size}"
 model_version = -1
 base_sequence_id = 1001
 log_file = "${base.logdir}/infer.log"
-throughput_per_gpu = 500
+throughput_per_gpu = 1000
 streams_per_gpu = "${base.streams_per_gpu}"
 num_workers = 4
 fduration = "${base.fduration}"

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -37,7 +37,7 @@ testing_prior = "bbhnet.priors.priors.end_o3_ratesandpops"
 fduration = 1
 valid_frac = 0.25
 cosmology = "bbhnet.priors.cosmologies.planck"
-streams_per_gpu = 3
+streams_per_gpu = 1
 
 [tool.typeo.scripts.generate-background]
 datadir = "${base.datadir}"
@@ -204,7 +204,7 @@ batch_size = "${base.inference_batch_size}"
 model_version = -1
 base_sequence_id = 1001
 log_file = "${base.logdir}/infer.log"
-throughput_per_gpu = 1600
+throughput_per_gpu = 500
 streams_per_gpu = "${base.streams_per_gpu}"
 num_workers = 4
 fduration = "${base.fduration}"

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -38,6 +38,7 @@ testing_prior = "bbhnet.priors.priors.end_o3_ratesandpops"
 fduration = 1
 valid_frac = 0.25
 cosmology = "bbhnet.priors.cosmologies.planck"
+streams_per_gpu = 3
 
 [tool.typeo.scripts.generate-background]
 datadir = "${base.datadir}"
@@ -146,12 +147,12 @@ kernel_length = "${base.kernel_length}"
 inference_sampling_rate = "${base.inference_sampling_rate}"
 sample_rate = "${base.sample_rate}"
 fduration = "${base.fduration}"
-highpass = "${base.highpass}"
 batch_size = "${base.inference_batch_size}"
 
 # repo/triton parameters
-instances = 2
-streams_per_gpu = 4
+bbhnet_instances = 4
+preproc_instances = 6
+streams_per_gpu = "${base.streams_per_gpu}"
 platform = "tensorrt_plan"
 verbose = false
 clean = true
@@ -206,7 +207,7 @@ model_version = -1
 base_sequence_id = 1001
 log_file = "${base.logdir}/infer.log"
 throughput_per_gpu = 1600
-streams_per_gpu = 4
+streams_per_gpu = "${base.streams_per_gpu}"
 num_workers = 4
 fduration = "${base.fduration}"
 verbose = false

--- a/projects/sandbox/pyproject.toml
+++ b/projects/sandbox/pyproject.toml
@@ -27,7 +27,6 @@ state_flag = "DCS-ANALYSIS_READY_C01:1"
 resnet = {layers = [2, 2, 2, 2], norm_groups = 8}
 repository_directory = "${BASE_DIR}/model_repo/" 
 force_generation = false
-kernel_length = 2
 inference_sampling_rate = 16
 inference_batch_size = 128
 minimum_frequency = 20
@@ -100,7 +99,7 @@ outdir = "${base.basedir}/training"
 
 # data generation and processing parameters
 sample_rate = "${base.sample_rate}"
-kernel_length = "${base.kernel_length}"
+kernel_length = 2
 fduration = "${base.fduration}"
 
 highpass = "${base.minimum_frequency}"
@@ -143,7 +142,6 @@ weights = "${base.basedir}/training/weights.pt"
 
 # input-output mapping info
 num_ifos = 2 
-kernel_length = "${base.kernel_length}" 
 inference_sampling_rate = "${base.inference_sampling_rate}"
 sample_rate = "${base.sample_rate}"
 fduration = "${base.fduration}"

--- a/projects/sandbox/train/train/train.py
+++ b/projects/sandbox/train/train/train.py
@@ -307,11 +307,7 @@ def main(
     # we just expose this as an arg? How will this fit in
     # to the broader-generalization scheme?
     preprocessor = Preprocessor(
-        2,
-        sample_rate,
-        kernel_length,
-        highpass=highpass,
-        fduration=fduration,
+        2, sample_rate=sample_rate, fduration=fduration
     )
 
     # fit the whitening module to the background then


### PR DESCRIPTION
Separating the preprocessor and neural network at export time so that the NN can be exported at reduced precision. Closes #276 . Inferring the inference `kernel_length` from the saved preprocessor weights at export time, so this argument can be removed.

Right now I'm topping out single GPU throughput at around 8,000 inf/s at a batch size of 128 on a V100. I've done some benchmarking with TensorRT's python APIs, and the max I can get it to is 10,000 inf/s, which improves on the full precision throughput of ~5,800 inf/s. So once you factor in the other models on the GPU eating up resources, this sounds about right.

The issue is that with older versions of the code (but with the same size model), I was able to top out single GPU throughput at around 25,000 inf/s. The possible disparities I can think of are
- TensorRT performance actually degrading over time
- BatchNorm -> GroupNorm slowing things down. This might seem unlikely, but Conv -> BatchNorm -> ReLU is a sufficiently common chain of operations that many frameworks (TensorRT included) have fused operators that can execute these really quickly in a single kernel call.

I'm going to spend some time today benchmarking these different possibilities to understand what's going on here and if there's a way we can recover some of this performance, so marking as a draft until this is worked out.

- [x] Sort out cause of throughput drop between older versions of the code and now
- [x] Finish updating scaling tests to account for different numbers of instances of NN and preprocessor