### PR TITLE
Reverted back to ConditionalPriorDict for `end_o3_ratesandpops`

### DIFF
--- a/libs/priors/bbhnet/priors/priors.py
+++ b/libs/priors/bbhnet/priors/priors.py
@@ -30,8 +30,8 @@ def uniform_extrinsic() -> PriorDict:
     prior = PriorDict()
     prior["dec"] = Cosine()
     prior["ra"] = Uniform(0, 2 * np.pi)
-    prior["theta_jn"] = 0
-    prior["phase"] = 0
+    prior["theta_jn"] = Sine()
+    prior["phase"] = Uniform(0, 2 * np.pi)
 
     return prior
 
@@ -91,13 +91,13 @@ def end_o3_ratesandpops(
     prior["redshift"] = UniformComovingVolume(
         0, 2, name="redshift", cosmology=cosmology
     )
-    prior["psi"] = 0
+    prior["psi"] = Uniform(0, np.pi)
     prior["a_1"] = Uniform(0, 0.998)
     prior["a_2"] = Uniform(0, 0.998)
     prior["tilt_1"] = Sine(unit=rad)
     prior["tilt_2"] = Sine(unit=rad)
     prior["phi_12"] = Uniform(0, 2 * np.pi)
-    prior["phi_jl"] = 0
+    prior["phi_jl"] = Uniform(0, 2 * np.pi)
 
     detector_frame_prior = False
     return prior, detector_frame_prior

--- a/libs/priors/bbhnet/priors/priors.py
+++ b/libs/priors/bbhnet/priors/priors.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from bilby.core.prior import (
+    ConditionalPowerLaw,
+    ConditionalPriorDict,
     Constraint,
     Cosine,
     Gaussian,
@@ -11,12 +13,12 @@ from bilby.core.prior import (
     Sine,
     Uniform,
 )
-from bilby.gw.prior import UniformSourceFrame
+from bilby.gw.prior import UniformComovingVolume, UniformSourceFrame
 
 if TYPE_CHECKING:
     from astropy.cosmology import Cosmology
 
-from bbhnet.priors.utils import mass_constraints, read_priors_from_file
+from bbhnet.priors.utils import mass_condition_powerlaw, read_priors_from_file
 
 # Unit names
 msun = r"$M_{\odot}$"
@@ -25,7 +27,7 @@ rad = "rad"
 
 
 def uniform_extrinsic() -> PriorDict:
-    prior = PriorDict(conversion_function=mass_constraints)
+    prior = PriorDict()
     prior["dec"] = Cosine()
     prior["ra"] = Uniform(0, 2 * np.pi)
     prior["theta_jn"] = 0
@@ -76,13 +78,17 @@ def spin_bbh(cosmology: Optional["Cosmology"] = None) -> PriorDict:
 
 def end_o3_ratesandpops(
     cosmology: Optional["Cosmology"] = None,
-) -> PriorDict:
-    prior = uniform_extrinsic()
-    prior["mass_1"] = PowerLaw(alpha=-2.35, minimum=2, maximum=100, unit=msun)
-    prior["mass_2"] = PowerLaw(alpha=1, minimum=2, maximum=100, unit=msun)
-    prior["mass_ratio"] = Constraint(0.02, 1)
-    prior["chirp_mass"] = Constraint(10, 100, unit=msun)
-    prior["redshift"] = UniformSourceFrame(
+) -> ConditionalPriorDict:
+    prior = ConditionalPriorDict(uniform_extrinsic())
+    prior["mass_1"] = PowerLaw(alpha=-2.35, minimum=10, maximum=100, unit=msun)
+    prior["mass_2"] = ConditionalPowerLaw(
+        condition_func=mass_condition_powerlaw,
+        alpha=1,
+        minimum=10,
+        maximum=100,
+        unit=msun,
+    )
+    prior["redshift"] = UniformComovingVolume(
         0, 2, name="redshift", cosmology=cosmology
     )
     prior["psi"] = 0

--- a/libs/priors/bbhnet/priors/utils.py
+++ b/libs/priors/bbhnet/priors/utils.py
@@ -6,6 +6,14 @@ import numpy as np
 from bilby.core.prior import Interped, PriorDict
 
 
+def mass_condition_powerlaw(reference_params, mass_1):
+    return dict(
+        alpha=reference_params["alpha"],
+        minimum=reference_params["minimum"],
+        maximum=mass_1,
+    )
+
+
 def mass_constraints(samples):
     if "mass_1" not in samples.keys() or "mass_2" not in samples.keys():
         raise KeyError("mass_1 and mass_1 must exist to have a mass_ratio")


### PR DESCRIPTION
This also switches back to `UniformComovingVolume`.

Histogram of `mass_1` distribution with desired distribution overlaid:
<img width="600" alt="image" src="https://user-images.githubusercontent.com/90333821/222296650-fb3a6fe6-0153-438e-922a-e1c455c7b9c3.png">
